### PR TITLE
Build first-pass data model as activerecord migrations

### DIFF
--- a/db/migrate/20190531004741_create_capabilities.rb
+++ b/db/migrate/20190531004741_create_capabilities.rb
@@ -1,0 +1,10 @@
+class CreateCapabilities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :capabilities do |t|
+      t.string :name
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531014002_create_capability_dependencies.rb
+++ b/db/migrate/20190531014002_create_capability_dependencies.rb
@@ -1,0 +1,8 @@
+class CreateCapabilityDependencies < ActiveRecord::Migration[5.2]
+  def change
+    create_table :capability_dependencies do |t|
+      t.column :parent_id, :bigint
+      t.column :required_id, :bigint
+    end
+  end
+end

--- a/db/migrate/20190531015319_create_architectures.rb
+++ b/db/migrate/20190531015319_create_architectures.rb
@@ -1,0 +1,9 @@
+class CreateArchitectures < ActiveRecord::Migration[5.2]
+  def change
+    create_table :architectures do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531015552_create_host_systems.rb
+++ b/db/migrate/20190531015552_create_host_systems.rb
@@ -1,0 +1,9 @@
+class CreateHostSystems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :host_systems do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531015706_create_operating_systems.rb
+++ b/db/migrate/20190531015706_create_operating_systems.rb
@@ -1,0 +1,9 @@
+class CreateOperatingSystems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :operating_systems do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531015959_create_languages.rb
+++ b/db/migrate/20190531015959_create_languages.rb
@@ -1,0 +1,9 @@
+class CreateLanguages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :languages do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531020134_create_applications.rb
+++ b/db/migrate/20190531020134_create_applications.rb
@@ -1,0 +1,9 @@
+class CreateApplications < ActiveRecord::Migration[5.2]
+  def change
+    create_table :applications do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531020339_create_platforms.rb
+++ b/db/migrate/20190531020339_create_platforms.rb
@@ -1,0 +1,11 @@
+class CreatePlatforms < ActiveRecord::Migration[5.2]
+  def change
+    create_table :platforms do |t|
+      t.string :name
+      t.belongs_to :host_system
+      t.belongs_to :operating_system
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531020705_create_implementations.rb
+++ b/db/migrate/20190531020705_create_implementations.rb
@@ -1,0 +1,11 @@
+class CreateImplementations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :implementations do |t|
+      t.string :name
+      t.belongs_to :language
+      t.belongs_to :capability  # note, this may well not be a `belongs_to` relationship
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531021333_create_join_table_deployed_implementations.rb
+++ b/db/migrate/20190531021333_create_join_table_deployed_implementations.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableDeployedImplementations < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :platforms, :implementations do |t|
+      # t.index [:platform_id, :implementation_id]
+      # t.index [:implementation_id, :platform_id]
+    end
+  end
+end

--- a/db/migrate/20190531021944_create_stacks.rb
+++ b/db/migrate/20190531021944_create_stacks.rb
@@ -1,0 +1,12 @@
+class CreateStacks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :stacks do |t|
+      t.string :name
+      t.belongs_to :application
+      t.belongs_to :capability
+      t.integer :paper
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_020134) do
+ActiveRecord::Schema.define(version: 2019_05_31_020339) do
 
   create_table "applications", force: :cascade do |t|
     t.string "name"
@@ -52,6 +52,16 @@ ActiveRecord::Schema.define(version: 2019_05_31_020134) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "platforms", force: :cascade do |t|
+    t.string "name"
+    t.integer "host_system_id"
+    t.integer "operating_system_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["host_system_id"], name: "index_platforms_on_host_system_id"
+    t.index ["operating_system_id"], name: "index_platforms_on_operating_system_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_014002) do
+ActiveRecord::Schema.define(version: 2019_05_31_015319) do
+
+  create_table "architectures", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "capabilities", force: :cascade do |t|
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_015319) do
+ActiveRecord::Schema.define(version: 2019_05_31_015552) do
 
   create_table "architectures", force: :cascade do |t|
     t.string "name"
@@ -28,6 +28,12 @@ ActiveRecord::Schema.define(version: 2019_05_31_015319) do
   create_table "capability_dependencies", force: :cascade do |t|
     t.bigint "parent_id"
     t.bigint "required_id"
+  end
+
+  create_table "host_systems", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_020339) do
+ActiveRecord::Schema.define(version: 2019_05_31_020705) do
 
   create_table "applications", force: :cascade do |t|
     t.string "name"
@@ -40,6 +40,16 @@ ActiveRecord::Schema.define(version: 2019_05_31_020339) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "implementations", force: :cascade do |t|
+    t.string "name"
+    t.integer "language_id"
+    t.integer "capability_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["capability_id"], name: "index_implementations_on_capability_id"
+    t.index ["language_id"], name: "index_implementations_on_language_id"
   end
 
   create_table "languages", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_020705) do
+ActiveRecord::Schema.define(version: 2019_05_31_021333) do
 
   create_table "applications", force: :cascade do |t|
     t.string "name"
@@ -50,6 +50,11 @@ ActiveRecord::Schema.define(version: 2019_05_31_020705) do
     t.datetime "updated_at", null: false
     t.index ["capability_id"], name: "index_implementations_on_capability_id"
     t.index ["language_id"], name: "index_implementations_on_language_id"
+  end
+
+  create_table "implementations_platforms", id: false, force: :cascade do |t|
+    t.integer "platform_id", null: false
+    t.integer "implementation_id", null: false
   end
 
   create_table "languages", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_021333) do
+ActiveRecord::Schema.define(version: 2019_05_31_021944) do
 
   create_table "applications", force: :cascade do |t|
     t.string "name"
@@ -77,6 +77,17 @@ ActiveRecord::Schema.define(version: 2019_05_31_021333) do
     t.datetime "updated_at", null: false
     t.index ["host_system_id"], name: "index_platforms_on_host_system_id"
     t.index ["operating_system_id"], name: "index_platforms_on_operating_system_id"
+  end
+
+  create_table "stacks", force: :cascade do |t|
+    t.string "name"
+    t.integer "application_id"
+    t.integer "capability_id"
+    t.integer "paper"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_id"], name: "index_stacks_on_application_id"
+    t.index ["capability_id"], name: "index_stacks_on_capability_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_015706) do
+ActiveRecord::Schema.define(version: 2019_05_31_015959) do
 
   create_table "architectures", force: :cascade do |t|
     t.string "name"
@@ -31,6 +31,12 @@ ActiveRecord::Schema.define(version: 2019_05_31_015706) do
   end
 
   create_table "host_systems", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "languages", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_015959) do
+ActiveRecord::Schema.define(version: 2019_05_31_020134) do
+
+  create_table "applications", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "architectures", force: :cascade do |t|
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_05_31_014002) do
+
+  create_table "capabilities", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "capability_dependencies", force: :cascade do |t|
+    t.bigint "parent_id"
+    t.bigint "required_id"
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_015552) do
+ActiveRecord::Schema.define(version: 2019_05_31_015706) do
 
   create_table "architectures", force: :cascade do |t|
     t.string "name"
@@ -31,6 +31,12 @@ ActiveRecord::Schema.define(version: 2019_05_31_015552) do
   end
 
   create_table "host_systems", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "operating_systems", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6259/58676000-5206a180-831c-11e9-89dc-8a1b37f13ee5.png)

Converting [whiteboarded discussions](https://github.com/jameswhite/capabilities/tree/master/design/20190530) into an ActiveRecord model. This won't be right at the outset, but gives us something to play with and iterate on.

 - [x] capabilities (`capabilities`)
 - [x] capabilities dependency [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) (`capability_dependencies`)
 - [x] architectures
 - [x] host systems
 - [x] operating systems
 - [x] languages
 - [x] applications
 - [x] platforms (aka "running instances" or "running hosts")
 - [x] implementations
 - [x] deployed implementations
 - [x] application stacks


cc @northrup @jameswhite 